### PR TITLE
fix: missing `:id` in main example of delete

### DIFF
--- a/reference-docs/device-notifications.rst
+++ b/reference-docs/device-notifications.rst
@@ -259,7 +259,7 @@ Cancel or Dismiss Notification
 ------------------------------
 
 ==============  ===============================================
-URL             /api/v2/device/notifications
+URL             /api/v2/device/notifications/:id
 Method          DELETE
 Authorization   basic
 ==============  ===============================================


### PR DESCRIPTION
As per subject.

Otherwise sending `DELETE /api/v2/device/notifications/` just causes an error.