### PR TITLE
Add full_rgb to device-display.rst

### DIFF
--- a/reference-docs/device-display.rst
+++ b/reference-docs/device-display.rst
@@ -92,7 +92,7 @@ Since version 2.1.0 ``screensaver`` node has been added::
 | ``height``           | Integer        |  Height of the display in pixels                                           |
 +----------------------+----------------+----------------------------------------------------------------------------+
 | ``type``             | Enum           |  Display type. Valid values are : ["monochrome", "grayscale", "color",     | 
-|                      |                |  "mixed"]                                                                  |
+|                      |                |  "mixed", "full_rgb"]                                                                  |
 +----------------------+----------------+----------------------------------------------------------------------------+
 
 


### PR DESCRIPTION
Lametric Sky's display is `full_rgb` - this PR adds it to the list of accepted display values.

Also, the Sky has a property named `on` in the display properties. Is this also valid for Time? If not, should I add it to this file as well?